### PR TITLE
Adding extra backup options

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,8 @@ repos:
             ".secrets.baseline",
             "--exclude-secrets",
             "redactedpassword",
+            "--exclude-secrets",
+            "hunter2",
           ]
 
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 # Role Name
 
-This role is designed to interact with a pfsense firewall to create and download a local backup of the firewalls configuration. This runs locally to interact with pfsense via the webinterface. 
+This role is designed to interact with a pfsense firewall to create and download a local backup of the firewalls configuration. This runs locally to interact with pfsense via the webinterface.
 
 By default it will download all availible data and options for pfSense backups (ssh keys, rrd data, extra services data...). If a `pfsense_encrypted_password` is supplied it will encrypt the backup file with this password. It will need to be supplied if using the backup file to restore pfSense.
 
 ## Role Variables
 
-| Name                          | Description                                    | Default                                                                                       |
-| ----------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| pfsense_hostname              | Hostname or IP of Fireall                      |                                                                                               |
-| pfsense_username              | Username to login to pfsense                   |                                                                                               |
-| pfsense_password              | password to login to pfsense                   |                                                                                               |
-| pfsense_backup_page           | url for backup page in web interface           | `diag_backup.php`                                                                             |
-| pfsense_backup_directory      | Local Backup Directory to save pfsense configr |                                                                                               |
-| pfsense_backup_filename       | Filename of the saved file                     | `'{{ pfsense_backup_directory }}/{{ pfsense_hostname }}-{{ ansible_date_time.iso8601 }}.xml'` |
-| pfsense_https                 | If using HTTPS to connect to firewall          | `true`                                                                                        |
-| pfsense_validate_certificates | Check for valid certificates                   | `true`                                                                                        |
-| pfsense_backup_no_log         | Hide output from ansible logs                  | `true`                                                                                        |
-| pfsense_backupssh         | Option to include the SSH keys for the firewall                | `true`                                                                                        |
-| pfsense_backupdata         | Option to include extra data such as DHCP leases and captive portal databases                  | `true`                                                                                        |
-| pfsense_donotbackuprrd         | Negate backup of the RRD files                | `false`                                                                                        |
-| pfsense_encrypted_password         | Password to encrypt the backup file               | `true`                                                                                        |
+| Name                          | Description                                                                   | Default                                                                                       |
+| ----------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| pfsense_hostname              | Hostname or IP of Fireall                                                     |                                                                                               |
+| pfsense_username              | Username to login to pfsense                                                  |                                                                                               |
+| pfsense_password              | password to login to pfsense                                                  |                                                                                               |
+| pfsense_backup_page           | url for backup page in web interface                                          | `diag_backup.php`                                                                             |
+| pfsense_backup_directory      | Local Backup Directory to save pfsense configr                                |                                                                                               |
+| pfsense_backup_filename       | Filename of the saved file                                                    | `'{{ pfsense_backup_directory }}/{{ pfsense_hostname }}-{{ ansible_date_time.iso8601 }}.xml'` |
+| pfsense_https                 | If using HTTPS to connect to firewall                                         | `true`                                                                                        |
+| pfsense_validate_certificates | Check for valid certificates                                                  | `true`                                                                                        |
+| pfsense_backup_no_log         | Hide output from ansible logs                                                 | `true`                                                                                        |
+| pfsense_backupssh             | Option to include the SSH keys for the firewall                               | `true`                                                                                        |
+| pfsense_backupdata            | Option to include extra data such as DHCP leases and captive portal databases | `true`                                                                                        |
+| pfsense_donotbackuprrd        | Negate backup of the RRD files                                                | `false`                                                                                       |
+| pfsense_encrypted_password    | Password to encrypt the backup file. Password will be needed for any restore  | `true`                                                                                        |
 
 ## Example Playbook
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Role Name
 
-This role is designed to interact with a pfsense firewall to create and download a local backup of the firewalls configuration. This runs locally to interact with pfsense via the webinterface. Currently it is limited to downloading just the basic configuration and does not include RRD Data or SSH keys as of writing.
+This role is designed to interact with a pfsense firewall to create and download a local backup of the firewalls configuration. This runs locally to interact with pfsense via the webinterface. 
+
+By default it will download all availible data and options for pfSense backups (ssh keys, rrd data, extra services data...). If a `pfsense_encrypted_password` is supplied it will encrypt the backup file with this password. It will need to be supplied if using the backup file to restore pfSense.
 
 ## Role Variables
 
@@ -15,6 +17,10 @@ This role is designed to interact with a pfsense firewall to create and download
 | pfsense_https                 | If using HTTPS to connect to firewall          | `true`                                                                                        |
 | pfsense_validate_certificates | Check for valid certificates                   | `true`                                                                                        |
 | pfsense_backup_no_log         | Hide output from ansible logs                  | `true`                                                                                        |
+| pfsense_backupssh         | Option to include the SSH keys for the firewall                | `true`                                                                                        |
+| pfsense_backupdata         | Option to include extra data such as DHCP leases and captive portal databases                  | `true`                                                                                        |
+| pfsense_donotbackuprrd         | Negate backup of the RRD files                | `false`                                                                                        |
+| pfsense_encrypted_password         | Password to encrypt the backup file               | `true`                                                                                        |
 
 ## Example Playbook
 
@@ -26,6 +32,9 @@ This role is designed to interact with a pfsense firewall to create and download
     - pfsense_username: 'pfbackup'
     - pfsense_password: 'redactedpassword'
     - pfsense_backup_directory: '/backups'
+    - pfsense_donotbackuprrd: true
+    - pfsense_encrypted_password: 'hunter2'
+
   roles:
     - role: ansible-role-pfsense-backup
 ```

--- a/README.md
+++ b/README.md
@@ -6,21 +6,21 @@ By default it will download all availible data and options for pfSense backups (
 
 ## Role Variables
 
-| Name                          | Description                                                                   | Default                                                                                       |
-| ----------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| pfsense_hostname              | Hostname or IP of Fireall                                                     |                                                                                               |
-| pfsense_username              | Username to login to pfsense                                                  |                                                                                               |
-| pfsense_password              | password to login to pfsense                                                  |                                                                                               |
-| pfsense_backup_page           | url for backup page in web interface                                          | `diag_backup.php`                                                                             |
-| pfsense_backup_directory      | Local Backup Directory to save pfsense configr                                |                                                                                               |
-| pfsense_backup_filename       | Filename of the saved file                                                    | `'{{ pfsense_backup_directory }}/{{ pfsense_hostname }}-{{ ansible_date_time.iso8601 }}.xml'` |
-| pfsense_https                 | If using HTTPS to connect to firewall                                         | `true`                                                                                        |
-| pfsense_validate_certificates | Check for valid certificates                                                  | `true`                                                                                        |
-| pfsense_backup_no_log         | Hide output from ansible logs                                                 | `true`                                                                                        |
-| pfsense_backupssh             | Option to include the SSH keys for the firewall                               | `true`                                                                                        |
-| pfsense_backupdata            | Option to include extra data such as DHCP leases and captive portal databases | `true`                                                                                        |
-| pfsense_donotbackuprrd        | Negate backup of the RRD files                                                | `false`                                                                                       |
-| pfsense_encrypted_password    | Password to encrypt the backup file. Password will be needed for any restore  | `true`                                                                                        |
+| Name                          | Description                                                                              | Default                                                                                       |
+| ----------------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| pfsense_hostname              | Hostname or IP of pfSense Firewall                                                       |                                                                                               |
+| pfsense_username              | Username to login to pfSense Firewall                                                    |                                                                                               |
+| pfsense_password              | password to login to pfSense Firewall                                                    |                                                                                               |
+| pfsense_backup_page           | url for backup page in web interface                                                     | `diag_backup.php`                                                                             |
+| pfsense_backup_directory      | Local Backup Directory to save pfSense Firewall backups                                  |                                                                                               |
+| pfsense_backup_filename       | Filename of the saved file                                                               | `'{{ pfsense_backup_directory }}/{{ pfsense_hostname }}-{{ ansible_date_time.iso8601 }}.xml'` |
+| pfsense_https                 | If using HTTPS to connect to firewall                                                    | `true`                                                                                        |
+| pfsense_validate_certificates | Check for valid SSL certificates                                                         | `true`                                                                                        |
+| pfsense_backup_no_log         | Hide output from ansible logs                                                            | `true`                                                                                        |
+| pfsense_backupssh             | Option for backup to include the SSH keys for the pfSense Firewall                       | `true`                                                                                        |
+| pfsense_backupdata            | Option for backup to include extra data such as DHCP leases and captive portal databases | `true`                                                                                        |
+| pfsense_donotbackuprrd        | Negate backup of the RRD files                                                           | `false`                                                                                       |
+| pfsense_encrypted_password    | Password to encrypt the backup file. Password will be needed for any restore             | `true`                                                                                        |
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,9 @@ pfsense_backup_filename: "{{ pfsense_backup_directory }}/{{ pfsense_hostname }}-
 pfsense_https: true
 pfsense_validate_certificates: true
 pfsense_backup_no_log: true
+
+# Backup Options
+pfsense_backupssh: true
+pfsense_backupdata: true
+pfsense_donotbackuprrd: false
+pfsense_encrypted_password: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -92,12 +92,12 @@
     body_format: form-urlencoded
     body:
       download: download
-      backupssh: "{{'yes' if (backupssh) | default(omit) }}"
-      backupdata: "{{'yes' if (backupdata) | default(omit) }}"
-      donotbackuprrd: "{{'yes' if (donotbackuprrd) | default(omit) }}"
-      encrypt: "{{'yes' if (encrypted_password | length) | default(omit) }}"
-      encrypt_password: "{{ (encrypted_password) | default(omit) }}"
-      encrypt_password_confirm: "{{ (encrypted_password ) | default(omit) }}"
+      backupssh: "{{'yes' if (pfsense_backupssh) | default(omit) }}"
+      backupdata: "{{'yes' if (pfsense_backupdata) | default(omit) }}"
+      donotbackuprrd: "{{'yes' if (pfsense_donotbackuprrd) | default(omit) }}"
+      encrypt: "{{'yes' if (pfsense_encrypted_password | length) | default(omit) }}"
+      encrypt_password: "{{ (pfsense_encrypted_password) | default(omit) }}"
+      encrypt_password_confirm: "{{ (pfsense_encrypted_password ) | default(omit) }}"
       __csrf_magic: "{{ pfsense_backup_csrf1 }}"
     headers:
       Cookie: "{{ pfsense_backup_cookie2 }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,11 +18,6 @@
   ansible.builtin.set_fact:
     pfsense_backup_protocol: "{{'http' if not (pfsense_https) else 'https'}}"
 
-- name: pfSense Backup | Obtain timestamp for saved backup file
-  debug:
-    var: ansible_date_time
-  no_log: "{{ pfsense_backup_no_log }}"
-
 - name: pfSense Backup | Obtain Cookies & CSRF Token
   ansible.builtin.uri:
     url: "{{ pfsense_backup_protocol }}://{{ pfsense_hostname }}/{{ pfsense_backup_page }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -97,6 +97,12 @@
     body_format: form-urlencoded
     body:
       download: download
+      backupssh: "{{'yes' if (backupssh) | default(omit) }}"
+      backupdata: "{{'yes' if (backupdata) | default(omit) }}"
+      donotbackuprrd: "{{'yes' if (donotbackuprrd) | default(omit) }}"
+      encrypt: "{{'yes' if (encrypted_password | length) | default(omit) }}"
+      encrypt_password: "{{ (encrypted_password) | default(omit) }}"
+      encrypt_password_confirm: "{{ (encrypted_password ) | default(omit) }}"
       __csrf_magic: "{{ pfsense_backup_csrf1 }}"
     headers:
       Cookie: "{{ pfsense_backup_cookie2 }}"


### PR DESCRIPTION
This PR adds extra backup options that can be toggled with vars (see new vars in defaults file)

By default this role will be verbose and try and download all data possible, again this can be toggled if you just want a basic backup. 

option to encrypt backups is added and is recommended for production use.